### PR TITLE
[PR] Ensure the trailing slash is on the site URL when adding args

### DIFF
--- a/plugins/p2-resolved-posts/p2-resolved-posts.php
+++ b/plugins/p2-resolved-posts/p2-resolved-posts.php
@@ -382,7 +382,7 @@ class P2_Resolved_Posts {
 				'nonce'         => wp_create_nonce( 'p2-resolve-' . $post_id ),
 				'mark'          => $next_state,
 			);
-		$link = add_query_arg( $args, get_site_url() );
+		$link = add_query_arg( $args, get_site_url( '/' ) );
 		return $link;
 	}
 


### PR DESCRIPTION
Without the slash, the URL for flagging as resolve and unresolved
returns as a 404
